### PR TITLE
Change Parcel file argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = plugin
 
 function plugin (file, options = {watch: false}) {
   return function (files, metalsmith, done) {
-    const bundler = new Parcel(path.join(metalsmith.directory(), file), options)
+    const bundler = new Parcel(file, options)
     bundler.bundle()
     return done()
   }


### PR DESCRIPTION
By passing the file argument as-is we can leverage the multiple files capability of Parcel:

`parcel(['js/index.js', css/index.scss'])`