### PR TITLE
Change Parcel file argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 const Parcel = require('parcel-bundler')
-const path = require('path')
 
 module.exports = plugin
 
 function plugin (file, options = {watch: false}) {
   return function (files, metalsmith, done) {
-    const bundler = new Parcel(path.join(metalsmith.directory(), file), options)
+    const bundler = new Parcel(file), options)
     bundler.bundle()
     return done()
   }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = plugin
 
 function plugin (file, options = {watch: false}) {
   return function (files, metalsmith, done) {
-    const bundler = new Parcel(file), options)
+    const bundler = new Parcel(file, options)
     bundler.bundle()
     return done()
   }


### PR DESCRIPTION
By passing the file argument as-is we can leverage the multiple files capability of Parcel:

`parcel(['js/index.js', css/index.scss'], {})`